### PR TITLE
feat: image processing pipeline complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ lerna-debug.log*
 
 # dotenv environment variable files
 .env
+.env.example
 .env.development.local
 .env.test.local
 .env.production.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/mongoose": "^11.0.3",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/serve-static": "^5.0.3",
         "axios": "^1.10.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
@@ -2914,6 +2915,32 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/serve-static": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-5.0.3.tgz",
+      "integrity": "sha512-0jFjTlSVSLrI+mot8lfm+h2laXtKzCvgsVStv9T1ZBZTDwS26gM5czIhIESmWAod0PfrbCDFiu9C1MglObL8VA==",
+      "dependencies": {
+        "path-to-regexp": "8.2.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.4",
+        "@nestjs/common": "^11.0.2",
+        "@nestjs/core": "^11.0.2",
+        "express": "^5.0.1",
+        "fastify": "^5.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "fastify": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/mongoose": "^11.0.3",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/serve-static": "^5.0.3",
     "axios": "^1.10.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,9 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TasksModule } from './tasks/tasks.module';
 import { ImagesModule } from './images/images.module';
 import { SharedModule } from './shared/shared.module';
+import { ServeStaticModule } from '@nestjs/serve-static';
+import { join } from 'path';
+
 
 @Module({
   imports: [
@@ -17,6 +20,10 @@ import { SharedModule } from './shared/shared.module';
     TasksModule,
     ImagesModule,
     SharedModule,
+    ServeStaticModule.forRoot({
+      rootPath: join(__dirname, '..', '..', 'output'),
+      serveRoot: '/output',
+    }),
   ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,7 +7,6 @@ import { SharedModule } from './shared/shared.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 
-
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,9 +11,11 @@ import { join } from 'path';
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     MongooseModule.forRootAsync({
-      useFactory: (configService: ConfigService) => ({
-        uri: configService.get<string>('MONGODB_URI'),
-      }),
+      useFactory: (configService: ConfigService) => {
+        const uri = configService.get<string>('MONGODB_URI');
+        console.log('🔗 Connecting to MongoDB:', uri);
+        return { uri };
+      },
       inject: [ConfigService],
     }),
     TasksModule,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import * as express from 'express';
@@ -8,7 +9,13 @@ async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   app.use('/output', express.static(join(__dirname, '..', 'output')));
-
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
   await app.listen(3000);
 }
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import * as express from 'express';
 import { join } from 'path';
 
 async function bootstrap() {
+  const port = process.env.PORT || 3000;
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   app.use('/output', express.static(join(__dirname, '..', 'output')));
@@ -16,6 +17,6 @@ async function bootstrap() {
       transform: true,
     }),
   );
-  await app.listen(3000);
+  await app.listen(port);
 }
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,14 @@
-import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import * as express from 'express';
+import { join } from 'path';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  app.useGlobalPipes(new ValidationPipe());
-  await app.listen(process.env.PORT ?? 3000);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
+  app.use('/output', express.static(join(__dirname, '..', 'output')));
+
+  await app.listen(3000);
 }
 bootstrap();

--- a/src/shared/pipes/validate-object-id.pipe.ts
+++ b/src/shared/pipes/validate-object-id.pipe.ts
@@ -1,0 +1,12 @@
+import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+import { isValidObjectId } from 'mongoose';
+
+@Injectable()
+export class ValidateObjectIdPipe implements PipeTransform {
+  transform(value: string) {
+    if (!isValidObjectId(value)) {
+      throw new BadRequestException(`Invalid ID format: ${value}`);
+    }
+    return value;
+  }
+}

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -1,4 +1,8 @@
 import { Module } from '@nestjs/common';
+import { IsValidOriginalPath } from './validators/is-valid-original-path';
 
-@Module({})
+@Module({
+  providers: [IsValidOriginalPath],
+  exports: [IsValidOriginalPath],
+})
 export class SharedModule {}

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { IsValidOriginalPath } from './validators/is-valid-original-path';
+import { ValidateObjectIdPipe } from './pipes/validate-object-id.pipe';
 
 @Module({
-  providers: [IsValidOriginalPath],
-  exports: [IsValidOriginalPath],
+  providers: [IsValidOriginalPath, ValidateObjectIdPipe],
+  exports: [IsValidOriginalPath, ValidateObjectIdPipe],
 })
 export class SharedModule {}

--- a/src/shared/utils/download-image.ts
+++ b/src/shared/utils/download-image.ts
@@ -8,7 +8,12 @@ export async function downloadImageToLocal(
 ): Promise<string> {
   const response = await axios.get<ArrayBuffer>(url, {
     responseType: 'arraybuffer',
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+      Accept: 'image/*,*/*;q=0.8',
+    },
   });
+
   const headers = response.headers as Record<string, string | undefined>;
   const contentType = headers['content-type'] ?? '';
   const ext = contentType.split('/')[1] || 'jpg';

--- a/src/shared/validators/is-valid-original-path.ts
+++ b/src/shared/validators/is-valid-original-path.ts
@@ -1,0 +1,29 @@
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import * as fs from 'fs';
+import * as path from 'path';
+
+@ValidatorConstraint({ name: 'isValidOriginalPath', async: false })
+export class IsValidOriginalPath implements ValidatorConstraintInterface {
+  validate(value: string): boolean {
+    if (!value || typeof value !== 'string') return false;
+
+    if (value.startsWith('http://') || value.startsWith('https://')) {
+      try {
+        new URL(value);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    const fullPath = path.resolve(value);
+    return fs.existsSync(fullPath);
+  }
+
+  defaultMessage() {
+    return `originalPath must be a valid URL or an existing file path`;
+  }
+}

--- a/src/tasks/dto/create-task.dto.ts
+++ b/src/tasks/dto/create-task.dto.ts
@@ -1,6 +1,16 @@
-import { IsString } from 'class-validator';
+import { IsString, IsNotEmpty, Validate } from 'class-validator';
+import { IsValidOriginalPath } from '../../shared/validators/is-valid-original-path';
+import { Transform } from 'class-transformer';
 
 export class CreateTaskDto {
   @IsString()
+  @IsNotEmpty()
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
+  @Validate(IsValidOriginalPath, {
+    message:
+      'originalPath must be a valid URL (http/https) or an existing local file path',
+  })
   originalPath: string;
 }

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -9,6 +9,7 @@ import {
 import { TasksService } from './tasks.service';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { TaskDocument } from './schemas/task.schemas';
+import { ValidateObjectIdPipe } from '../shared/pipes/validate-object-id.pipe';
 
 @Controller('tasks')
 export class TasksController {
@@ -24,13 +25,13 @@ export class TasksController {
     };
   }
 
-  @Get(':taskId')
-  async getTask(@Param('taskId') taskId: string): Promise<TaskDocument | null> {
-    return this.tasksService.findById(taskId);
+  @Get(':id')
+  async findOne(@Param('id', ValidateObjectIdPipe) id: string) {
+    return this.tasksService.findById(id);
   }
 
   @Get('/images/:id')
-  async getImagesByTaskId(@Param('id') id: string) {
+  async getImagesByTaskId(@Param('id', ValidateObjectIdPipe) id: string) {
     const task: TaskDocument | null = await this.tasksService.findById(id);
     if (!task) {
       throw new NotFoundException(`Task with id ${id} not found`);

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Post, Get, Param } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  Get,
+  Param,
+  NotFoundException,
+} from '@nestjs/common';
 import { TasksService } from './tasks.service';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { TaskDocument } from './schemas/task.schemas';
@@ -20,5 +27,18 @@ export class TasksController {
   @Get(':taskId')
   async getTask(@Param('taskId') taskId: string): Promise<TaskDocument | null> {
     return this.tasksService.findById(taskId);
+  }
+
+  @Get('/images/:id')
+  async getImagesByTaskId(@Param('id') id: string) {
+    const task: TaskDocument | null = await this.tasksService.findById(id);
+    if (!task) {
+      throw new NotFoundException(`Task with id ${id} not found`);
+    }
+
+    return {
+      taskId: id,
+      images: task.images ?? [],
+    };
   }
 }

--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Get, Param } from '@nestjs/common';
 import { TasksService } from './tasks.service';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { TaskDocument } from './schemas/task.schemas';
@@ -15,5 +15,10 @@ export class TasksController {
       status: task.status,
       price: task.price,
     };
+  }
+
+  @Get(':taskId')
+  async getTask(@Param('taskId') taskId: string): Promise<TaskDocument | null> {
+    return this.tasksService.findById(taskId);
   }
 }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -27,13 +27,15 @@ export class TasksService {
 
     const savedTask = (await createdTask.save()) as TaskDocument;
 
-    this.processTask((savedTask._id as unknown as string).toString(), originalPath).catch((error: unknown) => {
-      if (error instanceof Error) {
-        console.error('❌ Error al iniciar proceso:', error.message);
-      } else {
-        console.error('❌ Error al iniciar proceso:', error);
-      }
-    });
+    this.processTask((savedTask._id as string).toString(), originalPath).catch(
+      (error: unknown) => {
+        if (error instanceof Error) {
+          console.error('❌ Error al iniciar proceso:', error.message);
+        } else {
+          console.error('❌ Error al iniciar proceso:', error);
+        }
+      },
+    );
 
     return savedTask;
   }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -1,23 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Task, TaskDocument } from './schemas/task.schemas';
+import { Model } from 'mongoose';
+import { CreateTaskDto } from './dto/create-task.dto';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as sharp from 'sharp';
-import { Injectable } from '@nestjs/common';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
-import { Task, TaskDocument } from './schemas/task.schemas';
-import { CreateTaskDto } from './dto/create-task.dto';
 import { downloadImageToLocal } from '../shared/utils/download-image';
 import { getFileMd5 } from '../shared/utils/get-md5';
-import { Image, ImageDocument } from '../images/schemas/image.schemas';
+import { NotFoundException } from '@nestjs/common';
 
 @Injectable()
 export class TasksService {
-  constructor(
-    @InjectModel(Task.name) private taskModel: Model<TaskDocument>,
-    @InjectModel(Image.name) private imageModel: Model<ImageDocument>,
-  ) {}
+  constructor(@InjectModel(Task.name) private taskModel: Model<TaskDocument>) {}
 
-  async create(createTaskDto: CreateTaskDto): Promise<Task> {
+  async create(createTaskDto: CreateTaskDto): Promise<TaskDocument> {
     const { originalPath } = createTaskDto;
     const price = parseFloat((Math.random() * (50 - 5) + 5).toFixed(2));
 
@@ -28,20 +25,40 @@ export class TasksService {
       images: [],
     });
 
-    const savedTask = await createdTask.save();
+    const savedTask = (await createdTask.save()) as TaskDocument;
 
-    this.processTask(savedTask._id, originalPath).catch(console.error);
+    this.processTask((savedTask._id as unknown as string).toString(), originalPath).catch((error: unknown) => {
+      if (error instanceof Error) {
+        console.error('❌ Error al iniciar proceso:', error.message);
+      } else {
+        console.error('❌ Error al iniciar proceso:', error);
+      }
+    });
 
     return savedTask;
   }
 
-  private async processTask(taskId: string, inputPath: string) {
+  async findById(taskId: string): Promise<any> {
+    const task = await this.taskModel.findById(taskId).lean();
+    if (!task) {
+      throw new NotFoundException(`Task with ID ${taskId} not found`);
+    }
+    const { _id, status, price, images } = task;
+    const response: any = { taskId: _id, status, price };
+    if (status === 'completed') {
+      response.images = images;
+    }
+    return response;
+  }
+
+  private async processTask(taskId: string, inputPath: string): Promise<void> {
     try {
       const isUrl = inputPath.startsWith('http');
       const fileName = path.basename(inputPath).split('.')[0];
       const ext = path.extname(inputPath).replace('.', '') || 'jpg';
-      const inputDir = path.join(__dirname, '../../input');
-      const outputBase = path.join(__dirname, '../../output', fileName);
+      const inputDir = path.join(__dirname, '../../../input');
+      const outputBase = path.join(__dirname, '../../../output', fileName);
+
       fs.mkdirSync(outputBase, { recursive: true });
 
       const localPath = isUrl
@@ -49,29 +66,23 @@ export class TasksService {
         : inputPath;
 
       const resolutions = [1024, 800];
-      const imageVariants = [];
+      const imageVariants: { resolution: string; path: string }[] = [];
 
       for (const width of resolutions) {
         const md5 = getFileMd5(localPath);
-        const variantPath = path.join(outputBase, `${width}`, `${md5}.${ext}`);
-        fs.mkdirSync(path.dirname(variantPath), { recursive: true });
+        const outputPath = path.join(outputBase, `${width}`, `${md5}.${ext}`);
+        fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
-        await sharp(localPath).resize({ width }).toFile(variantPath);
+        await sharp(localPath).resize({ width }).toFile(outputPath);
 
-        const relativePath = variantPath.replace(
-          path.resolve(__dirname, '../../'),
+        const relativePath = outputPath.replace(
+          path.resolve(__dirname, '../../../'),
           '',
         );
 
-        await this.imageModel.create({
-          path: relativePath,
-          resolution: width.toString(),
-          md5,
-        });
-
         imageVariants.push({
           resolution: width.toString(),
-          path: relativePath,
+          path: `/${relativePath}`,
         });
       }
 
@@ -81,10 +92,11 @@ export class TasksService {
       });
     } catch (error) {
       if (error instanceof Error) {
-        console.error('❌ Error al procesar imagen:', error.message);
+        console.error('❌ Error procesando imagen:', error.message);
       } else {
-        console.error('❌ Error al procesar imagen:', error);
+        console.error('❌ Error inesperado:', error);
       }
+
       await this.taskModel.findByIdAndUpdate(taskId, {
         status: 'failed',
       });

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -82,7 +82,7 @@ export class TasksService {
 
         imageVariants.push({
           resolution: width.toString(),
-          path: `/${relativePath}`,
+          path: '/' + relativePath.replace(/\\/g, '/').replace(/^\/+/, ''),
         });
       }
 

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -38,17 +38,12 @@ export class TasksService {
     return savedTask;
   }
 
-  async findById(taskId: string): Promise<any> {
-    const task = await this.taskModel.findById(taskId).lean();
+  async findById(taskId: string): Promise<TaskDocument> {
+    const task = await this.taskModel.findById(taskId);
     if (!task) {
       throw new NotFoundException(`Task with ID ${taskId} not found`);
     }
-    const { _id, status, price, images } = task;
-    const response: any = { taskId: _id, status, price };
-    if (status === 'completed') {
-      response.images = images;
-    }
-    return response;
+    return task;
   }
 
   private async processTask(taskId: string, inputPath: string): Promise<void> {


### PR DESCRIPTION
This pull request introduces the complete implementation of the image processing workflow, including:

Creation of image processing tasks.

Background downloading and resizing of images from remote URLs.

Saving resized images in a structured output folder.

Serving processed images as static assets.

 Features Implemented
POST /tasks

Accepts a JSON body with an originalPath (can be a URL).

Creates a new task with pending status and a random price.

Starts image processing in the background.

GET /tasks/:taskId

Returns the task's status (pending, completed, or failed), price, and processed image variants (if completed).

Image Processing

Downloads the image locally if it's a remote URL.

Generates resized variants at 1024px and 800px width using sharp.

Computes MD5 hash to ensure unique file naming.

Stores output in output/<original>/<width>/<hash>.jpg.

Static File Serving

Images in the /output folder are served via ServeStaticModule.

Example: http://localhost:3000/output/<width>/<hash>.jpg

